### PR TITLE
Use sass-migration to fix divisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Uses the `(hover: hover)` media query, so we don't need additional checks, dropping support for 
   IE11 (#9)
+* Migrate divisions to using `math.div`(#21)
 
 ## 1.1.0 [2017-05-03])
 

--- a/utils/function/_em-size.scss
+++ b/utils/function/_em-size.scss
@@ -6,6 +6,8 @@
  *
  * @return {EM Value} - The EM value based on $value and $base
  */
+@use "sass:math";
+
 @function em-size($value, $base) {
-  @return ($value / $base) * 1em;
+  @return math.div($value, $base) * 1em;
 }

--- a/utils/function/_strip-unit.scss
+++ b/utils/function/_strip-unit.scss
@@ -1,6 +1,8 @@
 /*
  * Remove unit from value
  */
+@use "sass:math";
+
 @function strip-unit($value) {
-  @return $value / ($value * 0 + 1);
+  @return math.div($value, $value * 0 + 1);
 }

--- a/utils/mixin/_aspect-ratio.scss
+++ b/utils/mixin/_aspect-ratio.scss
@@ -5,6 +5,8 @@
  * @param {number} $height ($width) - Percentage height
  * @param {boolean} $relative (true) - Add relative position to element
  */
+@use "sass:math";
+
 @mixin aspect-ratio($width: 1, $height: $width, $relative: true) {
   @if ($relative == true) {
     position: relative;
@@ -13,6 +15,6 @@
   &:before {
     content: "";
     display: block;
-    padding-top: unquote(($height / $width) * 100 + "%");
+    padding-top: unquote(math.div($height, $width) * 100 + "%");
   }
 }

--- a/utils/mixin/shape/_arrow.scss
+++ b/utils/mixin/shape/_arrow.scss
@@ -16,7 +16,7 @@
     font: 0/0 serif;
   }
 
-  $size: round($size / 2);
+  $size: round($size * 0.5);
   $longSize: $size * $stretch;
 
   @if $direction == down {


### PR DESCRIPTION
Running `sass-migrator division --migrate-deps base.scss` to migrate all files to be compatible with the newest sass version that is more explicit about division because new css standards.

See https://sass-lang.com/documentation/breaking-changes/slash-div for more details.