### PR TITLE
Added screen reader only mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm i -S @mediamonks/scss-utils
 -   [pseudo](./utils/mixin/_pseudo.scss)
 -   [respond-to](./utils/mixin/_respond-to.scss)
 -   [size](./utils/mixin/_size.scss)
+-   [screen-reader-only](./utils/mixin/_screen-reader-only.scss)
 -   [text-ellipsis](./utils/mixin/_text-ellipsis.scss)
 -   [arrow](./utils/mixin/shape/_arrow.scss)
 

--- a/utils/mixin/_screen-reader-only.scss
+++ b/utils/mixin/_screen-reader-only.scss
@@ -1,0 +1,14 @@
+/**
+ * Only display content to screen readers
+ * See: http://a11yproject.com/posts/how-to-hide-content/
+ */
+@mixin screen-reader-only() {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}


### PR DESCRIPTION
This mixin hides an element to all devices except screen readers.
Naming up for debate, could be `@mixin screen-reader-only();` or `@visually-hidden();`