### PR TITLE
Remove the Global functions in favor of @use "sass" equivalent

### DIFF
--- a/utils/function/_font-weight.scss
+++ b/utils/function/_font-weight.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 /*
  * Get Font weight
  *
@@ -6,8 +8,8 @@
  * @return {Number} - The CSS based font weight on the name
  */
 @function font-weight($weight) {
-  @if (map-has-key($fontWeight, $weight)) {
-    @return map-get($fontWeight, $weight);
+  @if (map.has-key($fontWeight, $weight)) {
+    @return map.get($fontWeight, $weight);
   } @else {
     @warn 'Couldn\'t find the font-weight: #{$weight}';
   }

--- a/utils/function/_strip-unit.scss
+++ b/utils/function/_strip-unit.scss
@@ -2,9 +2,10 @@
  * Remove unit from value
  */
 @use "sass:math";
+@use "sass:meta";
 
 @function strip-unit($number) {
-  @if type-of($number) == 'number' and not unitless($number) {
+  @if meta.type-of($number) == 'number' and not math.is-unitless($number) {
     @return math.div($number, $number * 0 + 1);
   }
 

--- a/utils/function/_zindex.scss
+++ b/utils/function/_zindex.scss
@@ -1,3 +1,5 @@
+@use "sass:list";
+
 /**
  * Z-Index function
  *
@@ -7,7 +9,7 @@
  * @returns {number}
  */
 @function zindex($list, $element) {
-  $zIndex: index($list, $element);
+  $zIndex: list.index($list, $element);
 
   @if $zIndex {
     @return $zIndex;

--- a/utils/mixin/_respond-to.scss
+++ b/utils/mixin/_respond-to.scss
@@ -1,15 +1,17 @@
+@use "sass:map";
+
 /**
  * Respond To (Breakpoint)
  *
  * @param {string} $name - Name of the breakpoint used in $breakpoints
  */
 @function get-media-query($name) {
-  $query: map_get($mediaQueries, $name);
+  $query: map.get($mediaQueries, $name);
   @return "#{$query}";
 }
 
 @mixin respond-to($name) {
-  @if map-has-key($mediaQueries, $name) {
+  @if map.has-key($mediaQueries, $name) {
     @media #{get-media-query($name)} {
       @content;
     }

--- a/utils/mixin/shape/_arrow.scss
+++ b/utils/mixin/shape/_arrow.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 /**
  * Creates an arrow
  *
@@ -16,7 +18,7 @@
     font: 0/0 serif;
   }
 
-  $size: round($size * 0.5);
+  $size: math.round($size * 0.5);
   $longSize: $size * $stretch;
 
   @if $direction == down {


### PR DESCRIPTION
There were still some functions that use the global scss functions, as this all will be deprecated I've removed a few